### PR TITLE
feat: update terraform-aws-provider version to 3.x

### DIFF
--- a/.github/workflows/terraform_module.yml
+++ b/.github/workflows/terraform_module.yml
@@ -84,9 +84,7 @@ jobs:
     # Validate configuration with tfsec (https://github.com/tfsec/tfsec#use-as-github-action)
     steps:
     - name: Terraform security scan
-      uses: triat/terraform-security-scan@v2.1.0
+      uses: triat/terraform-security-scan@v2.2.3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tfsec_version: v0.39.3
 

--- a/examples/one_service_two_lbs/provider.tf
+++ b/examples/one_service_two_lbs/provider.tf
@@ -1,4 +1,3 @@
 provider "aws" {
-  region  = "us-east-1"
-  version = "~> 2.69"
+  region = "us-east-1"
 }

--- a/examples/one_service_two_lbs/versions.tf
+++ b/examples/one_service_two_lbs/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "~>3.2"
     }
   }
   required_version = ">= 0.13"

--- a/examples/public_only_to_github/main.tf
+++ b/examples/public_only_to_github/main.tf
@@ -26,7 +26,6 @@ module "web" {
 }
 
 provider "github" {
-  version = "~> 4.0"
 }
 
 data "github_ip_ranges" "cidrs" {}

--- a/examples/public_only_to_github/provider.tf
+++ b/examples/public_only_to_github/provider.tf
@@ -1,4 +1,3 @@
 provider "aws" {
-  region  = "us-east-1"
-  version = "~> 2.69"
+  region = "us-east-1"
 }

--- a/examples/public_only_to_github/versions.tf
+++ b/examples/public_only_to_github/versions.tf
@@ -1,10 +1,12 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "~>3.2"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~>4.0"
     }
   }
   required_version = ">= 0.13"

--- a/examples/simple/provider.tf
+++ b/examples/simple/provider.tf
@@ -1,4 +1,3 @@
 provider "aws" {
-  region  = "us-east-1"
-  version = "~> 2.69"
+  region = "us-east-1"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.69"
+      version = "~> 3.37"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
BREAKING CHANGE: this requires a major version change of the AWS provider and will
break consuming modules which do not also use the 3.x version of the AWS terraform
provider.

Jira: https://mixmaxhq.atlassian.net/browse/CORE-3755

#### Changes Made
 - Upgrade the AWS provider version to > 3.2.0

#### Potential Risks
 - This module breaks - we need to cut a version to test this, all linting and examples look okay.

#### Test Plan
 - Merge, cut a new major version release, and use in emailapps staging.

#### Release Plan
 - See above.

#### Checklist
- [x] Should this involve a live code review and/or demo? - Nope
